### PR TITLE
Add fail-fast package-lock.json sync check

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -28,19 +28,25 @@ jobs:
           node-version: "20"
 
       # -----------------------------
-      # 3. Install Dependencies
+      # 3. Check package-lock.json is up-to-date
+      # -----------------------------
+      - name: 🔒 Check package-lock.json Sync
+        run: npx --yes package-lock-utd@1.1.3
+
+      # -----------------------------
+      # 4. Install Dependencies
       # -----------------------------
       - name: 📦 Install Dependencies
         run: npm ci
 
       # -----------------------------
-      # 4. Run Lint & Formatting Check
+      # 5. Run Lint & Formatting Check
       # -----------------------------
       - name: 🧹 Run Lint & Formatting Check
         run: npx biome check .
 
       # -----------------------------
-      # 5. Build the Package
+      # 6. Build the Package
       # -----------------------------
       - name: 🏗️ Run Build
         run: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "setup-solr-action",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "setup-solr-action",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "devDependencies": {
         "@actions/core": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "contributors": [
     "Dhaval Gojiya <dhavalgojiya10@gmail.com>"
   ],
+  "repository": "https://github.com/dhavalgojiya/setup-solr-action",
+  "private": true,
   "license": "MIT",
   "main": "src/action.js",
   "scripts": {


### PR DESCRIPTION
## 📦 Lockfile Sync Check in CI

This PR adds a **fail-fast check for package-lock.json** in the CI pipeline to ensure it is always up-to-date with `package.json`

### ✅ What this PR does

- 🔒 **Add `package-lock-utd` check** using `npx --yes package-lock-utd@1.1.3` to verify lockfile is in sync
- ⚡ **Run this check before build/lint steps** to fail fast if lockfile is outdated
- ❌ **CI pipeline fails immediately** when the lockfile is out-of-sync, saving unnecessary build time

### 🖼 Example Failure

If the lockfile is not in sync, the CI will fail like this:

![Lockfile Out-of-Sync Example](https://github.com/user-attachments/assets/174751e1-a510-4601-94e5-306a56df165e)  

---

This ensures developers **cannot merge changes** that break the lockfile, keeping dependencies consistent across all environments.