### PR TITLE
Add Contributor Covenant Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We pledge to make our community welcoming, safe, and equitable for all.
+
+We are committed to fostering an environment that respects and promotes the dignity, rights, and contributions of all individuals, regardless of characteristics including race, ethnicity, caste, color, age, physical characteristics, neurodiversity, disability, sex or gender, gender identity or expression, sexual orientation, language, philosophy or religion, national or social origin, socio-economic position, level of education, or other status. The same privileges of participation are extended to everyone who participates in good faith and in accordance with this Covenant.
+
+## Encouraged Behaviors
+
+While acknowledging differences in social norms, we all strive to meet our community’s expectations for positive behavior. We also understand that our words and actions may be interpreted differently than we intend based on culture, background, or native language.
+
+With these considerations in mind, we agree to behave mindfully toward each other and act in ways that center our shared values, including:
+
+1. Respecting the purpose of our community, our activities, and our ways of gathering.
+2. Engaging kindly and honestly with others.
+3. Respecting different viewpoints and experiences.
+4. Taking responsibility for our actions and contributions.
+5. Gracefully giving and accepting constructive feedback.
+6. Committing to repairing harm when it occurs.
+7. Behaving in other ways that promote and sustain the well-being of our community.
+
+## Restricted Behaviors
+
+We agree to restrict the following behaviors in our community. Instances, threats, and promotion of these behaviors are violations of this Code of Conduct.
+
+1. Harassment. Violating explicitly expressed boundaries or engaging in unnecessary personal attention after any clear request to stop.
+2. Character attacks. Making insulting, demeaning, or pejorative comments directed at a community member or group of people.
+3. Stereotyping or discrimination. Characterizing anyone’s personality or behavior on the basis of immutable identities or traits.
+4. Sexualization. Behaving in a way that would generally be considered inappropriately intimate in the context or purpose of the community.
+5. Violating confidentiality. Sharing or acting on someone’s personal or private information without their permission.
+6. Endangerment. Causing, encouraging, or threatening violence or other harm toward any person or group.
+7. Behaving in other ways that threaten the well-being of our community.
+
+### Other Restrictions
+
+1. Misleading identity. Impersonating someone else for any reason, or pretending to be someone else to evade enforcement actions.
+2. Failing to credit sources. Not properly crediting the sources of content you contribute.
+3. Promotional materials. Sharing marketing or other commercial content in a way that is outside the norms of the community.
+4. Irresponsible communication. Failing to responsibly present content which includes, links or describes any other restricted behaviors.
+
+## Reporting an Issue
+
+Tensions can occur between community members even when they are trying their best to collaborate. Not every conflict represents a code of conduct violation, and this Code of Conduct reinforces encouraged behaviors and norms that can help avoid conflicts and minimize harm.
+
+When an incident does occur, it is important to report it promptly. To report a possible violation, please open an issue in this repository or contact the repository maintainers directly.
+
+Community Moderators take reports of violations seriously and will make every effort to respond in a timely manner. They will investigate all reports of code of conduct violations, reviewing messages, logs, and recordings, or interviewing witnesses and other participants. Community Moderators will keep investigation and enforcement actions as transparent as possible while prioritizing safety and confidentiality. In order to honor these values, enforcement actions are carried out in private with the involved parties, but communicating to the whole community may be part of a mutually agreed upon resolution.
+
+## Addressing and Repairing Harm
+
+If an investigation by the Community Moderators finds that this Code of Conduct has been violated, the following enforcement ladder may be used to determine how best to repair harm, based on the incident’s impact on the individuals involved and the community as a whole. Depending on the severity of a violation, lower rungs on the ladder may be skipped.
+
+1. **Warning**  
+   Event: A violation involving a single incident or series of actions.  
+   Consequence: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+2. **Temporary Ban**  
+   Event: A violation involving a series of actions or a single serious incident.  
+   Consequence: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+3. **Permanent Ban**  
+   Event: A pattern of repeated code of conduct violations that other steps on the ladder have failed to resolve, or a violation so serious that the Community Moderators determine there is no way to keep the community safe with this person as a member.  
+   Consequence: Access to all community spaces, tools, and communication channels is removed. In general, permanent bans should be rarely used, should have strong reasoning behind them, and should only be resorted to if working through other remedies has failed to change the behavior.  
+   Repair: There is no possible repair in cases of this severity.
+
+This enforcement ladder is intended as a guideline. It does not limit the ability of Community Managers to use their discretion and judgment, in keeping with the best interests of our community.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public or other spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 3.0, available at https://www.contributor-covenant.org/version/3/0/code_of_conduct
+
+Contributor Covenant is stewarded by the Organization for Ethical Source and licensed under CC BY-SA 4.0. To view a copy of this license, visit https://creativecommons.org/licenses/by-sa/4.0/
+
+For answers to common questions about Contributor Covenant, see the FAQ at https://www.contributor-covenant.org/faq.
+
+Translations are provided at https://www.contributor-covenant.org/translations.
+
+Additional enforcement and community guideline resources can be found at https://www.contributor-covenant.org/resources.
+
+The enforcement ladder was inspired by the work of Mozilla’s code of conduct team.


### PR DESCRIPTION

## Summary
This PR adds a [Contributor Covenant v3.0](https://www.contributor-covenant.org/version/3/0/) Code of Conduct to the repository to foster a welcoming and inclusive environment for all contributors.

* Adds `CODE_OF_CONDUCT.md` with community guidelines.
* Improves the repository’s community health score.
* Sets clear expectations for behavior and reporting procedures.
