### PR TITLE
Pin GitHub Actions to specific commit SHAs in CI workflows

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -30,7 +30,7 @@ jobs:
       # 1. Checkout Repository
       # -----------------------------
       - name: 📥 Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -19,7 +19,7 @@ jobs:
       # 1. Checkout Repository
       # -----------------------------
       - name: 📥 Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
@@ -27,7 +27,7 @@ jobs:
       # 2. Run Pre-commit hooks
       # -----------------------------
       - name: 🧹 Run Pre-commit hooks
-        uses: pre-commit/action@v3.0.1
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
 
   # -----------------------------
   # Job 2: Package Checks & Build
@@ -41,7 +41,7 @@ jobs:
       # 1. Checkout Repository
       # -----------------------------
       - name: 📥 Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
@@ -49,7 +49,7 @@ jobs:
       # 2. Setup Node.js
       # -----------------------------
       - name: ⚙️ Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: "20"
 
@@ -101,7 +101,7 @@ jobs:
       # 1. Checkout Repository
       # -----------------------------
       - name: 📥 Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -49,7 +49,7 @@ jobs:
       # 2. Setup Node.js
       # -----------------------------
       - name: ⚙️ Setup Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "20"
 


### PR DESCRIPTION
### Motivation
- Improve CI reproducibility and stability by pinning third-party GitHub Actions to immutable commit SHAs instead of floating tags.

### Description
- Updated workflow files `./.github/workflows/ci-release.yml` and `./.github/workflows/ci-test.yml` to replace `uses` references like `actions/checkout@v6`, `pre-commit/action@v3.0.1`, and `actions/setup-node@v6` with their corresponding commit SHAs (comments preserve the original tag for context).

### Testing
- No automated tests were executed as part of this change since it only modifies workflow references; the normal CI jobs (`pre-commit`, `package`, `solr-dev-test`, and `solr-release-test`) will run on the next push/PR to validate these workflow updates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed1bf28c8c8323b2fc7f43d441c04c)