### PR TITLE
Update pre-commit hook versions for biome, codespell, and shfmt

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,12 +39,12 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/biomejs/pre-commit
-    rev: v2.3.7
+    rev: v2.4.16
     hooks:
     -   id: biome-check
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.1
+    rev: v2.4.2
     hooks:
       - id: codespell
         args:
@@ -53,7 +53,7 @@ repos:
           - tomli
 
   - repo: https://github.com/scop/pre-commit-shfmt
-    rev: v3.12.0-2
+    rev: v3.13.1-1
     hooks:
       - id: shfmt
         args:


### PR DESCRIPTION
## Description

[pre-commit]
Bump biome to v2.4.16, codespell to v2.4.2, and shfmt to v3.13.1-1.