### PR TITLE
chore: add shellcheck, actionlint, and yamlfmt pre-commit hooks

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -3,7 +3,7 @@ name: Test Solr Action Release
 on:
   push:
     tags:
-      - "v[0-9]"   # Major version tag release (e.g., v1, v2, ..., v9)
+      - "v[0-9]"  # Major version tag release (e.g., v1, v2, ..., v9)
 
 jobs:
   # -----------------------------
@@ -30,7 +30,7 @@ jobs:
       # 1. Checkout Repository
       # -----------------------------
       - name: 📥 Checkout Repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           persist-credentials: false
 

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -2,9 +2,9 @@ name: Build & Test
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 jobs:
   # -----------------------------
@@ -19,7 +19,7 @@ jobs:
       # 1. Checkout Repository
       # -----------------------------
       - name: 📥 Checkout Repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           persist-credentials: false
 
@@ -27,7 +27,7 @@ jobs:
       # 2. Run Pre-commit hooks
       # -----------------------------
       - name: 🧹 Run Pre-commit hooks
-        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1
 
   # -----------------------------
   # Job 2: Package Checks & Build
@@ -41,7 +41,7 @@ jobs:
       # 1. Checkout Repository
       # -----------------------------
       - name: 📥 Checkout Repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           persist-credentials: false
 
@@ -49,7 +49,7 @@ jobs:
       # 2. Setup Node.js
       # -----------------------------
       - name: ⚙️ Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: "24"
           cache: "npm"
@@ -103,7 +103,7 @@ jobs:
       # 1. Checkout Repository
       # -----------------------------
       - name: 📥 Checkout Repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           persist-credentials: false
 
@@ -111,7 +111,7 @@ jobs:
       # 2. Setup Apache Solr (Local Action)
       # -----------------------------
       - name: ⚡ Setup Apache Solr Infrastructure (Local)
-        uses: ./   # Use local action.yml
+        uses: ./  # Use local action.yml
         with:
           solr-version: ${{ matrix.solr-version }}
           solr-core-name: ${{ env.SOLR_CORE_NAME }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,9 +3,7 @@
 # To enable these pre-commit hooks run:
 # `uv tool install pre-commit` or `brew install pre-commit`
 # Then in the project root directory run `pre-commit install`
-
 exclude: dist/
-
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
@@ -39,9 +37,9 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/biomejs/pre-commit
-    rev: v2.4.16
+    rev: v2.5.0
     hooks:
-    -   id: biome-check
+      - id: biome-check
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.2
@@ -60,6 +58,16 @@ repos:
           - --indent=4
           - --write
 
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1
+    hooks:
+      - id: shellcheck
+
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint
+
   - repo: https://github.com/hukkin/mdformat
     rev: 1.0.0
     hooks:
@@ -68,3 +76,8 @@ repos:
           - --number
         additional_dependencies:
           - mdformat-gfm
+
+  - repo: https://github.com/google/yamlfmt
+    rev: v0.21.0
+    hooks:
+      - id: yamlfmt

--- a/.yamlfmt
+++ b/.yamlfmt
@@ -1,0 +1,4 @@
+formatter:
+  type: basic
+  retain_line_breaks_single: true
+  pad_line_comments: 2

--- a/dist/scripts/setup-solr.sh
+++ b/dist/scripts/setup-solr.sh
@@ -23,13 +23,13 @@ SOLR_CORE_CONF="$SOLR_CORE_HOME/conf"
 # -----------------------------------------
 echo "🚀 Starting Solr container on host port $SOLR_HOST_PORT... ⏳"
 docker run -d \
-    -p $SOLR_HOST_PORT:$SOLR_CONTAINER_PORT \
-    solr:$SOLR_VERSION solr-precreate "$SOLR_CORE_NAME" $SOLR_SAMPLE_TECHPRODUCTS_CONFDIR
+    -p "$SOLR_HOST_PORT":"$SOLR_CONTAINER_PORT" \
+    solr:"$SOLR_VERSION" solr-precreate "$SOLR_CORE_NAME" "$SOLR_SAMPLE_TECHPRODUCTS_CONFDIR"
 
 # -----------------------------------------
 # Step 2: Get running container ID
 # -----------------------------------------
-SOLR_CONTAINER=$(docker ps -f ancestor=solr:$SOLR_VERSION --format '{{.ID}}' | head -n1)
+SOLR_CONTAINER=$(docker ps -f ancestor=solr:"$SOLR_VERSION" --format '{{.ID}}' | head -n1)
 
 if [ -z "$SOLR_CONTAINER" ]; then
     echo "❌ No running Solr container found for solr:$SOLR_VERSION"
@@ -105,10 +105,10 @@ echo "✅ Solr core [$SOLR_CORE_NAME] is healthy!"
 if [ -n "$SOLR_CUSTOM_CONFIGSET_PATH" ]; then
     echo "📦 Copying custom configs from '$SOLR_CUSTOM_CONFIGSET_PATH' to Solr core [$SOLR_CORE_NAME]... ⏳"
 
-    docker cp "$SOLR_CUSTOM_CONFIGSET_PATH/." $SOLR_CONTAINER:$SOLR_CORE_CONF
+    docker cp "$SOLR_CUSTOM_CONFIGSET_PATH/." "$SOLR_CONTAINER":"$SOLR_CORE_CONF"
 
     # Fix permissions to match Solr user inside the container
-    docker exec -u root $SOLR_CONTAINER chown -R solr:solr $SOLR_CORE_HOME
+    docker exec -u root "$SOLR_CONTAINER" chown -R solr:solr "$SOLR_CORE_HOME"
     echo "✅ Custom configs copied to Solr core [$SOLR_CORE_NAME] successfully"
 else
     echo "⚠️ No custom config path provided — skipping (optional step)"

--- a/src/scripts/setup-solr.sh
+++ b/src/scripts/setup-solr.sh
@@ -23,13 +23,13 @@ SOLR_CORE_CONF="$SOLR_CORE_HOME/conf"
 # -----------------------------------------
 echo "🚀 Starting Solr container on host port $SOLR_HOST_PORT... ⏳"
 docker run -d \
-    -p $SOLR_HOST_PORT:$SOLR_CONTAINER_PORT \
-    solr:$SOLR_VERSION solr-precreate "$SOLR_CORE_NAME" $SOLR_SAMPLE_TECHPRODUCTS_CONFDIR
+    -p "$SOLR_HOST_PORT":"$SOLR_CONTAINER_PORT" \
+    solr:"$SOLR_VERSION" solr-precreate "$SOLR_CORE_NAME" "$SOLR_SAMPLE_TECHPRODUCTS_CONFDIR"
 
 # -----------------------------------------
 # Step 2: Get running container ID
 # -----------------------------------------
-SOLR_CONTAINER=$(docker ps -f ancestor=solr:$SOLR_VERSION --format '{{.ID}}' | head -n1)
+SOLR_CONTAINER=$(docker ps -f ancestor=solr:"$SOLR_VERSION" --format '{{.ID}}' | head -n1)
 
 if [ -z "$SOLR_CONTAINER" ]; then
     echo "❌ No running Solr container found for solr:$SOLR_VERSION"
@@ -105,10 +105,10 @@ echo "✅ Solr core [$SOLR_CORE_NAME] is healthy!"
 if [ -n "$SOLR_CUSTOM_CONFIGSET_PATH" ]; then
     echo "📦 Copying custom configs from '$SOLR_CUSTOM_CONFIGSET_PATH' to Solr core [$SOLR_CORE_NAME]... ⏳"
 
-    docker cp "$SOLR_CUSTOM_CONFIGSET_PATH/." $SOLR_CONTAINER:$SOLR_CORE_CONF
+    docker cp "$SOLR_CUSTOM_CONFIGSET_PATH/." "$SOLR_CONTAINER":"$SOLR_CORE_CONF"
 
     # Fix permissions to match Solr user inside the container
-    docker exec -u root $SOLR_CONTAINER chown -R solr:solr $SOLR_CORE_HOME
+    docker exec -u root "$SOLR_CONTAINER" chown -R solr:solr "$SOLR_CORE_HOME"
     echo "✅ Custom configs copied to Solr core [$SOLR_CORE_NAME] successfully"
 else
     echo "⚠️ No custom config path provided — skipping (optional step)"


### PR DESCRIPTION
## Description

Add three new pre-commit hooks for shell, GitHub Actions, and YAML:

- shellcheck (v0.11.0.1): lints shell scripts for bugs
- actionlint (v1.7.12): lints GitHub Actions workflow files
- yamlfmt (v0.21.0): formats YAML, configured via .yamlfmt to retain single blank lines and pad inline comments by two spaces

Also bump biome-check to v2.5.0 and normalize spacing between hook repos to a single blank line.

Fix the SC2086 issues shellcheck found in src/scripts/setup-solr.sh by quoting variable expansions, and rebuild dist/ via npm run all so the bundled script and workflow files match the formatter output.