### PR TITLE
chore: migrate pre-commit workflow to prek

### DIFF
--- a/.github/workflows/prek.yml
+++ b/.github/workflows/prek.yml
@@ -1,4 +1,4 @@
-name: Pre-commit
+name: Prek
 
 on:
   push:
@@ -16,9 +16,9 @@ permissions:
 
 jobs:
   # -----------------------------
-  # Job: Pre-commit
+  # Job: Prek
   # -----------------------------
-  pre-commit:
+  prek:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -31,7 +31,7 @@ jobs:
           persist-credentials: false
 
       # -----------------------------
-      # 2. Run Pre-commit hooks
+      # 2. Run prek hooks
       # -----------------------------
-      - name: 🧹 Run Pre-commit hooks
-        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1
+      - name: 🧹 Run prek hooks
+        uses: j178/prek-action@e98a699c41eb69ab013a45817a0406469a748f8d  # v2.0.5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,11 @@
-# Learn more about this config here: https://pre-commit.com/
+# Hooks are run with prek (https://prek.j178.dev/), a drop-in replacement for
+# pre-commit that reuses this same .pre-commit-config.yaml file.
+# Unlike pre-commit (written in Python), prek is written in Rust and ships as a
+# single dependency-free binary for faster, simpler installs.
 
-# To enable these pre-commit hooks run:
-# `uv tool install pre-commit` or `brew install pre-commit`
-# Then in the project root directory run `pre-commit install`
+# To enable these hooks run:
+# `uv tool install prek` or `brew install prek`
+# Then in the project root directory run `prek install`
 exclude: dist/
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@ ______________________________________________________________________
   - [📑 Table of Contents](#-table-of-contents)
   - [🛠️ Getting Started](#%EF%B8%8F-getting-started)
   - [🧹 Code Quality (Linting & Formatting)](#-code-quality-linting--formatting)
+  - [🪝 Git Hooks (prek)](#-git-hooks-prek)
   - [📦 Build](#-build)
   - [⚡ All-in-One Command](#-all-in-one-command)
   - [🧪 Testing Locally](#-testing-locally)
@@ -65,6 +66,38 @@ We use [Biome](https://biomejs.dev/) for linting and formatting, along with [shf
   ```bash
   npm run format:sh
   ```
+
+______________________________________________________________________
+
+## 🪝 Git Hooks (prek)
+
+We use [prek](https://prek.j178.dev/) to run our Git hooks. prek is a drop-in
+replacement for [pre-commit](https://pre-commit.com/) that reuses the same
+[`.pre-commit-config.yaml`](.pre-commit-config.yaml). Unlike pre-commit (written
+in Python), prek is written in Rust and ships as a single dependency-free binary
+for faster, simpler installs.
+
+- Install prek:
+
+  ```bash
+  uv tool install prek   # or: brew install prek
+  ```
+
+- Enable the hooks in your local clone:
+
+  ```bash
+  prek install
+  ```
+
+  The hooks now run automatically on every `git commit`.
+
+- Run all hooks against the whole repository manually:
+
+  ```bash
+  prek run --all-files
+  ```
+
+  > The same hooks run in CI, so running them locally helps you catch issues before pushing.
 
 ______________________________________________________________________
 


### PR DESCRIPTION
## Description

Switch CI and local Git hooks to [prek](https://prek.j178.dev/), a Rust-based drop-in replacement for pre-commit that reuses the same `.pre-commit-config.yaml`

Special Thanks to [prek](https://prek.j178.dev/) creator: @j178

- Replace `pre-commit/action` with `j178/prek-action` in CI and rename the workflow to prek.yml
- Update `.pre-commit-config.yaml` install instructions to use prek
- Document prek setup in CONTRIBUTING.md