### PR TITLE
chore: bump biome pre-commit hook to v2.5.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/biomejs/pre-commit
-    rev: v2.5.0
+    rev: v2.5.1
     hooks:
       - id: biome-check
 


### PR DESCRIPTION
## Description

Bumps the [biomejs/pre-commit](https://github.com/biomejs/pre-commit) hook from `v2.5.0` to `v2.5.1` in `.pre-commit-config.yaml`.
